### PR TITLE
Add a preliminary Krun setup for running renaissance.

### DIFF
--- a/krun_ext_common.py
+++ b/krun_ext_common.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019 King's College London
+# Created by the Software Development Team <http://soft-dev.org/>
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT
+# or http://opensource.org/licenses/MIT>, or the UPL-1.0 license
+# <http://opensource.org/licenses/UPL> at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+import sys
+import json
+import subprocess
+import tempfile
+import csv
+import os
+
+
+def make_temp_file():
+    """Make a temproary file and return its path"""
+    with tempfile.NamedTemporaryFile() as f:
+        return f.name
+
+
+def run(args, benchmark, num_iters, tmp_file):
+    """Runs the process execution and prints result JSON to stdout"""
+
+    # Krun expects to see the results printed in JSON format to stdout. We
+    # redirect anything the benchmarks print on stdout to stderr.
+    subprocess.run(args, shell=False, stdout=sys.stderr.fileno())
+
+    wallclock_times = [-0.0] * num_iters
+    with open(tmp_file) as f:
+        rows = iter(csv.reader(f))
+
+        headers = rows.__next__()
+        assert headers[0] == "benchmark"
+        assert headers[1] == "nanos"
+
+        for i, row in enumerate(rows):
+            assert row[0] == benchmark
+            wallclock_times[i] = int(row[1]) / 1000000000  # nanos -> seconds.
+
+    assert len(wallclock_times) == num_iters
+
+    js = {
+        "wallclock_times": wallclock_times,
+        "core_cycle_counts": [],
+        "aperf_counts": [],
+        "mperf_counts": [],
+    }
+
+    sys.stdout.write("%s\n" % json.dumps(js))
+
+    os.unlink(tmp_file)

--- a/krun_ext_graal_ce.py
+++ b/krun_ext_graal_ce.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019 King's College London
+# Created by the Software Development Team <http://soft-dev.org/>
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT
+# or http://opensource.org/licenses/MIT>, or the UPL-1.0 license
+# <http://opensource.org/licenses/UPL> at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+"""
+Graal CE script for use with Krun's ExternalSuiteVMDef.
+"""
+
+import sys
+from krun_ext_common import make_temp_file, run
+
+RENAISSANCE_V = "0.9.0"
+GRAALCE_V = "1.0.0-rc16"
+
+_, benchmark, num_iters, param, instr = sys.argv
+temp_file = make_temp_file()
+
+# Ensure the -Xms/-Xmx args match the stack/heap values in the Krun config!
+args = [
+    "graalvm-ce-%s/bin/java" % GRAALCE_V,
+    "-Xms12G", "-Xmx12G", "-jar", "renaissance-gpl-%s.jar" % RENAISSANCE_V,
+    "-r", num_iters, "--csv", temp_file, benchmark
+]
+
+run(args, benchmark, int(num_iters), temp_file)

--- a/krun_ext_graal_ce_hotspot.py
+++ b/krun_ext_graal_ce_hotspot.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019 King's College London
+# Created by the Software Development Team <http://soft-dev.org/>
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT
+# or http://opensource.org/licenses/MIT>, or the UPL-1.0 license
+# <http://opensource.org/licenses/UPL> at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+"""
+Graal CE (running the normal HotSpot compiler) script for use with Krun's
+ExternalSuiteVMDef.
+"""
+
+import sys
+from krun_ext_common import make_temp_file, run
+
+RENAISSANCE_V = "0.9.0"
+GRAALCE_V = "1.0.0-rc16"
+
+_, benchmark, num_iters, param, instr = sys.argv
+temp_file = make_temp_file()
+
+# Ensure the -Xms/-Xmx args match the stack/heap values in the Krun config!
+args = [
+    "graalvm-ce-%s/bin/java" % GRAALCE_V,
+    "-Xms12G", "-Xmx12G", "-XX:-EnableJVMCI", "-XX:-UseJVMCICompiler",
+    "-jar", "renaissance-gpl-%s.jar" % RENAISSANCE_V,
+    "-r", num_iters, "--csv", temp_file, benchmark
+]
+
+run(args, benchmark, int(num_iters), temp_file)

--- a/renaissance.krun
+++ b/renaissance.krun
@@ -1,0 +1,54 @@
+# Krun config file for running the renaissance suite using Krun's
+# ExternalSuiteVMDef.
+#
+# Note that you will have to make the experiment directory world-writable since
+# the runner expects to make a temporary directory at runtime. Sadly we can't
+# grant only the Krun user this access prior to running the process executions,
+# as the pre-execution scripts run before the Krun user is created.
+
+import os
+from krun.vm_defs import ExternalSuiteVMDef
+
+DIR = os.getcwd()
+
+N_EXECUTIONS = 10
+ITERATIONS_ALL_VMS = 2000
+
+MAIL_TO = []
+
+# These must match the arguments passed to to the runner in krun_ext_*.py
+HEAP_LIMIT = 1024 * 1024 * 1024 * 12
+STACK_LIMIT = 1024 * 1024 * 1024 * 12
+
+VARIANTS = {
+    "default-ext": None,
+}
+
+VMS = {
+    'graal-ce': {
+        'vm_def': ExternalSuiteVMDef(os.path.join(DIR, "krun_ext_graal_ce.py")),
+        'variants': ['default-ext'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
+    'graal-ce-hotspot': {
+        'vm_def': ExternalSuiteVMDef(os.path.join(DIR, "krun_ext_graal_ce_hotspot.py")),
+        'variants': ['default-ext'],
+        'n_iterations': ITERATIONS_ALL_VMS,
+    },
+}
+
+# Benchmark parameters unused in this experiment, so set them all zero.
+BENCHMARKS = {
+    "chi-square": 0,
+    "future-genetic": 0,
+    "gauss-mix": 0,
+    "naive-bayes": 0,
+    "rx-scrabble": 0,
+    "scala-stm-bench7": 0,
+    "scala-kmeans": 0,
+    "scrabble": 0,
+}
+
+SKIP = []
+
+# XXX pre/post exec commands.


### PR DESCRIPTION
Here's the initial work that takes advantage of `ExternalScriptVMDef` from https://github.com/softdevteam/krun/pull/388.

Raising a draft for early comments.

To do:
 - pre/post exec commands.
 - fix user change (read below)
 - test output with warmup_stats

### user change

Some part of their runner expects to be able to write into `./tmp-jars-XXXXXXXXXXXXXXX` (where the Xs are a load of numbers) and this isn't compatible with Krun's user change:
```
[2019-05-15 17:04:50: DEBUG] sync disks...                                                              
[2019-05-15 17:04:51: WARNING] SIMULATED: `time.sleep(30)` (--quick)                                                                    
[2019-05-15 17:04:51: INFO] stderr: May 15, 2019 5:04:51 PM org.renaissance.util.ModuleLoader getForGroup
[2019-05-15 17:04:51: INFO] stderr: SEVERE: Failed to load renaissance-harness: ./tmp-jars-5173250879876792459                                       
[2019-05-15 17:04:51: INFO] stderr: May 15, 2019 5:04:51 PM org.renaissance.Launcher main               
[2019-05-15 17:04:51: INFO] stderr: SEVERE: Failed to start the suite: Failed to load renaissance-harness: ./tmp-jars-5173250879876792459
[2019-05-15 17:04:51: INFO] stderr: org.renaissance.util.ModuleLoadingException: Failed to load renaissance-harness: ./tmp-jars-5173250879876792459
```

Ideally the harness should store those things under `$TMP` somwhere. Then they'd be properly blasted at reboot time.