### PR TITLE
Split setting up the VM and benchmarks from running.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.csv
+graalvm-ce-*
+*.jar
+target/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # Renaissance benchmark reproduction
 
-In order to run:
+To fetch the VM and the benchmarks:
+```sh
+$ ./setup.sh
+```
+
+To run using the simple runner (without Krun):
 
 ```sh
 $ ./run_benchmarks.sh
 ```
+
+To run using Krun, see the included Krun config file, `renaissance.krun`.

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -9,7 +9,12 @@
 # at your option. This file may not be copied, modified, or distributed except according to those
 # terms.
 
+# This script runs the benchmarks (outside of Krun). For a version of the
+# experiment you can run under Krun, see renaissance.krun.
+
 set -e
+
+sh setup.sh
 
 RENAISSANCE_V="0.9.0"
 GRAALCE_V="1.0.0-rc16"
@@ -19,15 +24,6 @@ GRAALCE_V="1.0.0-rc16"
 BENCHMARKS="chi-square,future-genetic,gauss-mix,naive-bayes,rx-scrabble,scala-stm-bench7,scala-kmeans,scrabble"
 PEXECS=10
 IPITERS=2000
-
-if [ ! -f renaissance-gpl-${RENAISSANCE_V}.jar ]; then
-    wget https://github.com/renaissance-benchmarks/renaissance/releases/download/v${RENAISSANCE_V}/renaissance-gpl-${RENAISSANCE_V}.jar
-fi
-
-if [ ! -d graalvm-ce-${GRAALCE_V} ]; then
-    wget https://github.com/oracle/graal/releases/download/vm-${GRAALCE_V}/graalvm-ce-${GRAALCE_V}-linux-amd64.tar.gz
-    tar xfz graalvm-ce-${GRAALCE_V}-linux-amd64.tar.gz
-fi
 
 i=0
 while [ $i -lt ${PEXECS} ]; do

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,26 @@
+#! /bin/sh
+
+# Copyright (c) 2019 King's College London created by the Software Development Team
+# <http://soft-dev.org/>
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+# at your option. This file may not be copied, modified, or distributed except according to those
+# terms.
+
+# This script fetches binary releases of the VM and the benchmarks.
+
+set -e
+
+RENAISSANCE_V="0.9.0"
+GRAALCE_V="1.0.0-rc16"
+
+if [ ! -f renaissance-gpl-${RENAISSANCE_V}.jar ]; then
+    wget https://github.com/renaissance-benchmarks/renaissance/releases/download/v${RENAISSANCE_V}/renaissance-gpl-${RENAISSANCE_V}.jar
+fi
+
+if [ ! -d graalvm-ce-${GRAALCE_V} ]; then
+    wget https://github.com/oracle/graal/releases/download/vm-${GRAALCE_V}/graalvm-ce-${GRAALCE_V}-linux-amd64.tar.gz
+    tar xfz graalvm-ce-${GRAALCE_V}-linux-amd64.tar.gz
+fi


### PR DESCRIPTION
Hi,

With the Krun experiment, we'd want to fetch the VMs and benchmarks, then invoke Krun manually. Under this scenario, we don't want to run the benchmarks (at least not outside of Krun), so split the `run_benchmarks.sh` script in two.

OK?