### PR TITLE
Add pre/post commands.

### DIFF
--- a/renaissance.krun
+++ b/renaissance.krun
@@ -51,4 +51,22 @@ BENCHMARKS = {
 
 SKIP = []
 
-# XXX pre/post exec commands.
+# Pre/post commands for a Debian 9 system using postfix for sending mail.
+# Make sure the interfaces you want to be taken down are marked `auto` in
+# /etc/networking/interfaces otherwise ifup won't work.
+PING_HOST = "bencher8.soft-dev.org"
+PRE_EXECUTION_CMDS = [
+    "while true; do sudo ifdown -a; sleep 5; ping -q -c 10 %s || break; done" % PING_HOST,
+    "sudo systemctl stop cron",
+    "sudo systemctl stop postfix",
+    "sudo systemctl stop systemd-tmpfiles-clean.timer",
+    "sudo systemctl stop ssh",
+]
+
+POST_EXECUTION_CMDS = [
+    "while true; do ping -c 3 -q %s && break; sudo ifdown -a; sleep 5; sudo ifup -a; done" % PING_HOST,
+    "sudo systemctl start ssh || true",
+    "sudo systemctl start cron || true",
+    "sudo systemctl start postfix || true",
+    "sudo systemctl start systemd-tmpfiles-clean.timer || true",
+]


### PR DESCRIPTION
This is based on the commands from the warmup experiment:
https://github.com/softdevteam/warmup_experiment/blob/2ac614cd16361575d55aa027f5b6009971565c7d/warmup.krun#L164-L188

Differences:
 * ifup/ifdown are now the preferred way to bring interfaces up and
   down.
 * The system we are using doesn't have atd installed, so don't try to
   stop it.

Tested without reboots.