### PR TITLE
Add the latest version of OpenJ9.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,11 @@ GRAALCE_V=1.0.0-rc16
 GRAALCE_DIR=graalvm-ce-${GRAALCE_V}
 GRAALCE_TGZ=graalvm-ce-${GRAALCE_V}-linux-amd64.tar.gz
 
-setup: ${RENAISSANCE_JAR} ${GRAALCE_DIR}
+J9_V=0.15.1
+J9_TGZ=OpenJDK12U-jdk_x64_linux_openj9_12.0.2_10_openj9-${J9_V}.tar.gz
+J9_DIR=OpenJDK12U-jdk_x64_linux_openj9_12.0.2_10_openj9-${J9_V}
+
+setup: ${RENAISSANCE_JAR} ${GRAALCE_DIR} ${J9_DIR}
 
 ${RENAISSANCE_JAR}:
 	${FETCH} https://github.com/renaissance-benchmarks/renaissance/releases/download/v${RENAISSANCE_V}/${RENAISSANCE_JAR}
@@ -27,9 +31,16 @@ ${GRAALCE_TGZ}:
 ${GRAALCE_DIR}: ${GRAALCE_TGZ}
 	tar xfz ${GRAALCE_TGZ}
 
+${J9_TGZ}:
+	${FETCH} https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10_openj9-0.15.1/${J9_TGZ}
+
+${J9_DIR}: ${J9_TGZ}
+	tar xzf ${J9_TGZ}
+	mv jdk-12.0.2+10 ${J9_DIR}
+
 run-standalone: setup
 	sh run_benchmarks.sh
 
 .PHONY: clean
 clean:
-	rm -rf ${RENAISSANCE_JAR} ${GRAALCE_TGZ} ${GRAALCE_DIR}
+	rm -rf ${RENAISSANCE_JAR} ${GRAALCE_TGZ} ${GRAALCE_DIR} ${J9_TGZ} ${J9_DIR}

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -16,10 +16,14 @@ set -e
 
 RENAISSANCE_V="0.9.0"
 GRAALCE_V="1.0.0-rc16"
+J9_V="0.15.1"
+
 # We run all benchmarks. Some of these are very slow.
 # For a reduced set of fast benchmarks, use:
 #BENCHMARKS="chi-square,future-genetic,gauss-mix,naive-bayes,rx-scrabble,scala-stm-bench7,scala-kmeans,scrabble"
 BENCHMARKS="akka-uct,als,chi-square,db-shootout,dec-tree,dotty,dummy,finagle-chirper,finagle-http,fj-kmeans,future-genetic,gauss-mix,log-regression,mnemonics,movie-lens,naive-bayes,neo4j-analytics,page-rank,par-mnemonics,philosophers,reactors,rx-scrabble,scala-kmeans,scala-stm-bench7,scrabble"
+# db-shootout crashes with a null pointer exception under J9.
+J9_BENCHMARKS="akka-uct,als,chi-square,dec-tree,dotty,dummy,finagle-chirper,finagle-http,fj-kmeans,future-genetic,gauss-mix,log-regression,mnemonics,movie-lens,naive-bayes,neo4j-analytics,page-rank,par-mnemonics,philosophers,reactors,rx-scrabble,scala-kmeans,scala-stm-bench7,scrabble"
 
 PEXECS=10
 IPITERS=2000
@@ -34,8 +38,15 @@ while [ $i -lt ${PEXECS} ]; do
 
     # Graal CE
     graalvm-ce-${GRAALCE_V}/bin/java -Xms12G -Xmx12G -jar renaissance-gpl-${RENAISSANCE_V}.jar -r ${IPITERS} --csv graalvm-ce-pexec-${i}.csv $BENCHMARKS
+
+    # OpenJ9
+    ./OpenJDK12U-jdk_x64_linux_openj9_12.0.2_10_openj9-${J9_V}/bin/java \
+        -Xms12G -Xmx12G -jar renaissance-gpl-${RENAISSANCE_V}.jar \
+        -r ${IPITERS} --csv openj9-pexec-${i}.csv ${J9_BENCHMARKS}
+
     i=$(($i + 1))
 done
 
 ./convert_to_krun.py -o openjdk.csv openjdk-pexec*.csv
 ./convert_to_krun.py -o graalvm-ce.csv graalvm-ce-pexec*.csv
+./convert_to_krun.py -o openj9.csv openj9-pexec*.csv


### PR DESCRIPTION
This just adds OpenJ9 to the point where we can run the benchmarks standalone.

One benchmark crashes, which I've skipped (null ptr).

Next will come code to make it run under Krun.