### PR TITLE
Skip movie-lens on OpenJ9. Runs out of heap.

### DIFF
--- a/renaissance.krun
+++ b/renaissance.krun
@@ -86,6 +86,9 @@ SKIP = [
     # null ptr exception in teardown.
     "db-shootout:openj9:default-ext",
 
+    # Runs out of heap -- same as Graal.
+    "movie-lens:openj9:default-ext",
+
     # === Skip on Graal ===
     # Runs out of heap:
     # https://github.com/renaissance-benchmarks/renaissance/issues/187


### PR DESCRIPTION
Perhaps in the next run we can give the VMs more heap, but for now we need to use the same heap limit as Graal used.