### PR TITLE
Update the VMs and the renaissance version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 graalvm-ce-*
 *.jar
 target/
+paths.sh

--- a/Makefile
+++ b/Makefile
@@ -9,34 +9,42 @@
 
 FETCH=wget
 
-RENAISSANCE_V=0.9.0
+RENAISSANCE_V=0.10.0
 RENAISSANCE_JAR=renaissance-gpl-${RENAISSANCE_V}.jar
 
-GRAALCE_V=1.0.0-rc16
-GRAALCE_DIR=graalvm-ce-${GRAALCE_V}
-GRAALCE_TGZ=graalvm-ce-${GRAALCE_V}-linux-amd64.tar.gz
+# For the VMs, we use the latest versions that target JDK11 at the time of writing.
+GRAALCE_V=19.3.0
+GRAALCE_DIR=graalvm-ce-java11-${GRAALCE_V}
+GRAALCE_TGZ=graalvm-ce-java11-linux-amd64-${GRAALCE_V}.tar.gz
 
-J9_V=0.15.1
-J9_TGZ=OpenJDK12U-jdk_x64_linux_openj9_12.0.2_10_openj9-${J9_V}.tar.gz
-J9_DIR=OpenJDK12U-jdk_x64_linux_openj9_12.0.2_10_openj9-${J9_V}
+J9_V=0.17.0
+J9_TGZ=OpenJDK11U-jdk_x64_linux_openj9_11.0.5_10_openj9-${J9_V}.tar.gz
+J9_DIR=OpenJDK11U-jdk_x64_linux_openj9_11.0.5_10_openj9-${J9_V}
+
+PATHS_SH=paths.sh
+
+TOP_DIR=`pwd`
 
 setup: ${RENAISSANCE_JAR} ${GRAALCE_DIR} ${J9_DIR}
+	echo OPENJ9_DIR=${TOP_DIR}/${J9_DIR} > ${PATHS_SH}
+	echo GRAALCE_DIR=${TOP_DIR}/${GRAALCE_DIR} >> ${PATHS_SH}
+	echo RENAISSANCE_JAR=${TOP_DIR}/${RENAISSANCE_JAR} >> ${PATHS_SH}
 
 ${RENAISSANCE_JAR}:
 	${FETCH} https://github.com/renaissance-benchmarks/renaissance/releases/download/v${RENAISSANCE_V}/${RENAISSANCE_JAR}
 
 ${GRAALCE_TGZ}:
-	${FETCH} https://github.com/oracle/graal/releases/download/vm-${GRAALCE_V}/${GRAALCE_TGZ}
+	${FETCH} https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAALCE_V}/${GRAALCE_TGZ}
 
 ${GRAALCE_DIR}: ${GRAALCE_TGZ}
 	tar xfz ${GRAALCE_TGZ}
 
 ${J9_TGZ}:
-	${FETCH} https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10_openj9-0.15.1/${J9_TGZ}
+	${FETCH} https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5%2B10_openj9-${J9_V}/${J9_TGZ}
 
 ${J9_DIR}: ${J9_TGZ}
 	tar xzf ${J9_TGZ}
-	mv jdk-12.0.2+10 ${J9_DIR}
+	mv jdk-11.0.5+10 ${J9_DIR}
 
 run-standalone: setup
 	sh run_benchmarks.sh

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -14,16 +14,18 @@
 
 set -e
 
-RENAISSANCE_V="0.9.0"
-GRAALCE_V="1.0.0-rc16"
-J9_V="0.15.1"
+DIRNAME=`dirname $0`
+
+if [ ! -f ${DIRNAME}/paths.sh ]; then
+    echo You need to run 'make setup' before running this 1>&2
+    exit 1
+fi
+. ${DIRNAME}/paths.sh
 
 # We run all benchmarks. Some of these are very slow.
 # For a reduced set of fast benchmarks, use:
 #BENCHMARKS="chi-square,future-genetic,gauss-mix,naive-bayes,rx-scrabble,scala-stm-bench7,scala-kmeans,scrabble"
-BENCHMARKS="akka-uct,als,chi-square,db-shootout,dec-tree,dotty,dummy,finagle-chirper,finagle-http,fj-kmeans,future-genetic,gauss-mix,log-regression,mnemonics,movie-lens,naive-bayes,neo4j-analytics,page-rank,par-mnemonics,philosophers,reactors,rx-scrabble,scala-kmeans,scala-stm-bench7,scrabble"
-# db-shootout crashes with a null pointer exception under J9.
-J9_BENCHMARKS="akka-uct,als,chi-square,dec-tree,dotty,dummy,finagle-chirper,finagle-http,fj-kmeans,future-genetic,gauss-mix,log-regression,mnemonics,movie-lens,naive-bayes,neo4j-analytics,page-rank,par-mnemonics,philosophers,reactors,rx-scrabble,scala-kmeans,scala-stm-bench7,scrabble"
+BENCHMARKS="akka-uct,als,chi-square,db-shootout,dec-tree,dotty,dummy,finagle-chirper,finagle-http,fj-kmeans,future-genetic,gauss-mix,log-regression,mnemonics,movie-lens,naive-bayes,neo4j-analytics,page-rank,par-mnemonics,philosophers,reactors,rx-scrabble,scala-doku,scala-kmeans,scala-stm-bench7,scrabble"
 
 PEXECS=10
 IPITERS=2000
@@ -34,15 +36,15 @@ while [ $i -lt ${PEXECS} ]; do
     #  https://github.com/renaissance-benchmarks/measurements/blob/7d3f09e05df3c5477fabe531ec5effc07e33f7aa/README.md
 
     # Graal CE running the normal HotSpot compiler
-    graalvm-ce-${GRAALCE_V}/bin/java -Xms12G -Xmx12G -XX:-EnableJVMCI -XX:-UseJVMCICompiler -jar renaissance-gpl-${RENAISSANCE_V}.jar -r ${IPITERS} --csv openjdk-pexec-${i}.csv $BENCHMARKS
+    ${GRAALCE_DIR}/bin/java -Xms12G -Xmx12G -XX:-EnableJVMCI -XX:-UseJVMCICompiler -jar ${RENAISSANCE_JAR} -r ${IPITERS} --csv openjdk-pexec-${i}.csv $BENCHMARKS
 
     # Graal CE
-    graalvm-ce-${GRAALCE_V}/bin/java -Xms12G -Xmx12G -jar renaissance-gpl-${RENAISSANCE_V}.jar -r ${IPITERS} --csv graalvm-ce-pexec-${i}.csv $BENCHMARKS
+    ${GRAALCE_DIR}/bin/java -Xms12G -Xmx12G -jar ${RENAISSANCE_JAR} -r ${IPITERS} --csv graalvm-ce-pexec-${i}.csv $BENCHMARKS
 
     # OpenJ9
-    ./OpenJDK12U-jdk_x64_linux_openj9_12.0.2_10_openj9-${J9_V}/bin/java \
-        -Xms12G -Xmx12G -jar renaissance-gpl-${RENAISSANCE_V}.jar \
-        -r ${IPITERS} --csv openj9-pexec-${i}.csv ${J9_BENCHMARKS}
+    ${OPENJ9_DIR}/bin/java \
+        -Xms12G -Xmx12G -jar ${RENAISSANCE_JAR} \
+        -r ${IPITERS} --csv openj9-pexec-${i}.csv ${BENCHMARKS}
 
     i=$(($i + 1))
 done


### PR DESCRIPTION
Later PRs will add additional benchmarking suites and update the Krun config. For now this only makes `run_benchmarks.sh` work using the new VMs and renaissance versions.

Note that db-shootout no longer crashes on OpenJ9.

There's also a new benchmark `scala-doku`.