### PR TITLE
Skip another problematic benchmark, allow more extra native heap memory.

### DIFF
--- a/experiment.krun
+++ b/experiment.krun
@@ -22,8 +22,8 @@ ITERATIONS_ALL_VMS = 2000
 
 MAIL_TO = []
 
-# We allow 2GiB of native heap in addition to the Java heap.
-HEAP_LIMIT = 1024 * 1024 * (JAVA_HEAP_GB + 2)
+# We allow extra native heap in addition to the Java heap.
+HEAP_LIMIT = 1024 * 1024 * (JAVA_HEAP_GB + 4)
 STACK_LIMIT = 1024 * 1024 # 1GB
 
 VARIANTS = {

--- a/krun_ext_common.py
+++ b/krun_ext_common.py
@@ -97,6 +97,8 @@ SKIP_SPECJVM = {
         "specjvm__compiler.compiler",
         # spec.harness.StopBenchmarkException: Error invoking bmSetupBenchmarkMethod
         "specjvm__compiler.sunflow",
+        # java.sql.SQLException: Failed to create database 'derby_dir/name1'
+        "specjvm__derby",
     ]
 }
 


### PR DESCRIPTION
See the commit messages for justifications.

Note that both issues are OpenJ9 specific.